### PR TITLE
Don't delete message from SQS when handler encounters error.

### DIFF
--- a/lib/queue.js
+++ b/lib/queue.js
@@ -174,9 +174,16 @@ Queue.prototype.pull = function (handler, options) {
               handler(output) :
               Promise.denodeify(handler)(output);
           })
-          .then(function () {
-            return queue._deleteMessage(message);
-          })
+          .then(
+            function () {
+              return queue._deleteMessage(message);
+            },
+            function(err) {
+              // Error handling message, don't delete from sqs.
+              queue.emit('error', err);
+              return Promise.resolve();
+            }
+          )
           .then(function () {
             process.nextTick(function () {
               queue.emit('message processed', message);


### PR DESCRIPTION
Please sanity check line 184, the `Promise.resolve()` statement -- I have to confess I'm not the most familiar with the Promise interface so let me know if that is not the optimal way to move the promise chain to the next step.
